### PR TITLE
ProteinData can have multiple sequences?

### DIFF
--- a/KBaseStructure.spec
+++ b/KBaseStructure.spec
@@ -48,7 +48,7 @@ module KBaseStructure {
   */
   typedef structure {
     mol_id id;
-    string sequence;
+    list<string> sequence;
     string md5;
     uniref_id uniref_id;
     genome_ref genome_ref;


### PR DESCRIPTION
if a pdb means one ModelProteinStructure means one ProteinData, then the ProteinData needs to accommodate multiple sequences, not just concatenate the multiple polypeptides into a single sequence