### PR TITLE
Change the ProteinStructures's lists ProteinStructures and experiment…

### DIFF
--- a/KBaseStructure.spec
+++ b/KBaseStructure.spec
@@ -174,8 +174,8 @@ module KBaseStructure {
     @optional experimental_structures description
   */
   typedef structure {
-    list<ModelProteinStructure> model_structures;
-    list<ExperimentalProteinStructure> experimental_structures;
+    list<object_ref> model_structures;
+    list<object_ref> experimental_structures;
     int total_structures;
     string description;
   } ProteinStructures;


### PR DESCRIPTION
…al_structures to point to object_ref instead of the structure objects